### PR TITLE
Upgraded bouncy castle version from 1.70 to 1.71

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,8 @@
   <dependencies>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
-      <version>1.70</version>
+      <artifactId>bcpkix-jdk18on</artifactId>
+      <version>1.71</version>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
Addressed issue https://github.com/heroku/env-keystore/issues/45 by upgrading bouncy castle library