### PR TITLE
Convert heroku/env-keystore to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: heroku/env-keystore/ci
+on:
+  push:
+jobs:
+  maven:
+    runs-on: sfdc-hk-ubuntu-latest
+    strategy:
+      matrix:
+        executor:
+        - openjdk-8
+        - openjdk-11
+    steps:
+    - uses: actions/checkout@v2
+    - run: "./mvnw clean test"
+    - name: Save test results
+      run: |-
+        mkdir -p ~/test-results/junit/
+        find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/test-results/junit/ \;
+      if: always()
+    - uses: actions/upload-artifact@v2
+      with:
+        path: "~/test-results"
+    - uses: actions/upload-artifact@v2
+      with:
+        path: "~/test-results/junit"


### PR DESCRIPTION
Pipeline migrated from [Circle CI](https://app.circleci.com/pipelines/github/heroku/env-keystore) :tada:

## Manual steps

Perform the follow steps to complete the migration:

### heroku/env-keystore/ci
- [ ] Ensure a runner with the following labels exists: sfdc-hk-ubuntu-latest