### PR TITLE
Migrate from `bcpkix-jdk15on` to `bcpkix-jdk18on`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Migrate from bcpkix-jdk15on to bcpkix-jdk18on, fixing security issues with bouncycastle. ([#91](https://github.com/heroku/env-keystore/pull/91))
 
 ## [1.1.8] - 2023-10-09
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,8 +43,8 @@
     <dependencies>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
-            <version>1.70</version>
+            <artifactId>bcpkix-jdk18on</artifactId>
+            <version>1.78.1</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
Migrate from `bcpkix-jdk15on` to `bcpkix-jdk18on`. The former was historically used to denote a Java 5+ compatible version of the dependency. The package was renamed and changed to a Java 8+ version at some point. The old dependency doesn't get any more updates and somehow Dependabot wasn't able to figure this out for us. 

I will investigate why this happened and how we can prevent this from happening in the future.

The upgrade to Java 8+ is not a problem since this library requires Java 8 anyways.

Reported by @khfds2024 in #90 - Thanks!