### PR TITLE
Further reduce team review request noise from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,3 +7,4 @@
 # by Dependabot or release automation, to reduce team review request noise.
 CHANGELOG.md @Malax
 pom.xml @Malax
+/.github/workflows/ @Malax


### PR DESCRIPTION
We already request language owner review for various automation and Dependabot related PRs, to reduce the amount of review request notification noise sent to the language owner team alias.

This adds the GitHub Actions workflow directory to this list too, so that Dependabot PRs that bump the Actions versions are treated the same as the language-specific Dependabot PRs.

GUS-W-18951033.