### PR TITLE
Deploy to Central Publishing Portal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,9 +35,9 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '11'
-          server-id: ossrh
+          server-id: central
           server-username: MAVEN_CENTRAL_USERNAME
-          server-password: MAVEN_CENTRAL_TOKEN
+          server-password: MAVEN_CENTRAL_PASSWORD
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
@@ -69,7 +69,7 @@ jobs:
         run: ./mvnw --batch-mode deploy
         env:
           MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-          MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
 
       - name: Create GitHub Release

--- a/pom.xml
+++ b/pom.xml
@@ -17,9 +17,9 @@
     </licenses>
     <developers>
         <developer>
-            <id>codefinger</id>
-            <name>Joe Kutner</name>
-            <email>jpkutner@gmail.com</email>
+            <id>malax</id>
+            <name>Manuel Fuchs</name>
+            <email>manuel.fuchs@salesforce.com</email>
         </developer>
     </developers>
     <scm>
@@ -31,12 +31,6 @@
         <system>GitHub</system>
         <url>https://github.com/heroku/env-keystore/issues/new</url>
     </issueManagement>
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-    </distributionManagement>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
@@ -107,14 +101,12 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.7.0</version>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.8.0</version>
                 <extensions>true</extensions>
                 <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    <publishingServerId>central</publishingServerId>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
As of June 30, 2025 OSSRH has reached end of life and has been shut down. All OSSRH namespaces have been migrated to Central Publisher Portal.

This PR updates the release automation and Maven deploy configuration to use the new Central Publishing Portal API directly. We will not use the [OSSRH staging api](https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/) which is a compatibility layer.