### PR TITLE
Harden `BasicKeyStore` temp file handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Create the temporary keystore file in `BasicKeyStore.storeTemp()` with owner-only permissions on POSIX filesystems. ([#152](https://github.com/heroku/env-keystore/pull/152))
 - Always delete the temporary keystore file in `BasicKeyStore.asFile()`, even when the consumer throws an exception. ([#152](https://github.com/heroku/env-keystore/pull/152))
 
+### Deprecated
+
+- Deprecate all disk-IO methods on `EnvKeyStore` and `BasicKeyStore` (`store(OutputStream)`, `store(Path)`, `storeTemp()`, `asFile(Consumer<File>)`). Writing keystore material to disk is out of scope for this library and will be removed in a subsequent release. Use `toBytes()` or `toInputStream()` and handle I/O in the caller. ([#152](https://github.com/heroku/env-keystore/pull/152))
+
 ## [1.1.13] - 2026-04-20
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Create the temporary keystore file in `BasicKeyStore.storeTemp()` with owner-only permissions on POSIX filesystems. ([#152](https://github.com/heroku/env-keystore/pull/152))
+- Always delete the temporary keystore file in `BasicKeyStore.asFile()`, even when the consumer throws an exception. ([#152](https://github.com/heroku/env-keystore/pull/152))
 
 ## [1.1.13] - 2026-04-20
 

--- a/src/main/java/com/heroku/sdk/BasicKeyStore.java
+++ b/src/main/java/com/heroku/sdk/BasicKeyStore.java
@@ -88,7 +88,7 @@ public class BasicKeyStore {
 
   public byte[] toBytes() throws CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException {
     ByteArrayOutputStream bos = new ByteArrayOutputStream();
-    this.store(bos);
+    this.keystore.store(bos, password.toCharArray());
     bos.close();
     return bos.toByteArray();
   }

--- a/src/main/java/com/heroku/sdk/BasicKeyStore.java
+++ b/src/main/java/com/heroku/sdk/BasicKeyStore.java
@@ -93,14 +93,44 @@ public class BasicKeyStore {
     return bos.toByteArray();
   }
 
+  /**
+   * @deprecated Writing the keystore to disk is out of scope for this library and will be removed
+   * in a subsequent release. Most callers do not need a file at all: use the in-memory
+   * {@link #keyStore()}, or {@link #toBytes()} / {@link #toInputStream()} if bytes are required.
+   * If you truly need a file, implement it in your own code with the permission and cleanup
+   * guarantees appropriate to your environment. Getting this right is filesystem-specific and
+   * security-sensitive: writing a private key to disk with default permissions can expose it to
+   * other local users (CWE-378), so treat this responsibility as yours to own.
+   */
+  @Deprecated
   public void store(OutputStream out) throws CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException {
     this.keystore.store(out, password.toCharArray());
   }
 
+  /**
+   * @deprecated Writing the keystore to disk is out of scope for this library and will be removed
+   * in a subsequent release. Most callers do not need a file at all: use the in-memory
+   * {@link #keyStore()}, or {@link #toBytes()} / {@link #toInputStream()} if bytes are required.
+   * If you truly need a file, implement it in your own code with the permission and cleanup
+   * guarantees appropriate to your environment. Getting this right is filesystem-specific and
+   * security-sensitive: writing a private key to disk with default permissions can expose it to
+   * other local users (CWE-378), so treat this responsibility as yours to own.
+   */
+  @Deprecated
   public void store(Path path) throws CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException {
     Files.write(path, toBytes());
   }
 
+  /**
+   * @deprecated Writing the keystore to disk is out of scope for this library and will be removed
+   * in a subsequent release. Most callers do not need a file at all: use the in-memory
+   * {@link #keyStore()}, or {@link #toBytes()} / {@link #toInputStream()} if bytes are required.
+   * If you truly need a file, implement it in your own code with the permission and cleanup
+   * guarantees appropriate to your environment. Getting this right is filesystem-specific and
+   * security-sensitive: writing a private key to disk with default permissions can expose it to
+   * other local users (CWE-378), so treat this responsibility as yours to own.
+   */
+  @Deprecated
   public File storeTemp() throws IOException, CertificateException, NoSuchAlgorithmException, KeyStoreException {
     // Owner-only permissions are only enforced on POSIX filesystems. On non-POSIX
     // (e.g. Windows) the file is created with the default inherited ACL.
@@ -117,6 +147,16 @@ public class BasicKeyStore {
     }
   }
 
+  /**
+   * @deprecated Writing the keystore to disk is out of scope for this library and will be removed
+   * in a subsequent release. Most callers do not need a file at all: use the in-memory
+   * {@link #keyStore()}, or {@link #toBytes()} / {@link #toInputStream()} if bytes are required.
+   * If you truly need a file, implement it in your own code with the permission and cleanup
+   * guarantees appropriate to your environment. Getting this right is filesystem-specific and
+   * security-sensitive: writing a private key to disk with default permissions can expose it to
+   * other local users (CWE-378), so treat this responsibility as yours to own.
+   */
+  @Deprecated
   public void asFile(Consumer<File> c) throws IOException, CertificateException, NoSuchAlgorithmException, KeyStoreException {
     File temp = storeTemp();
     try {

--- a/src/main/java/com/heroku/sdk/BasicKeyStore.java
+++ b/src/main/java/com/heroku/sdk/BasicKeyStore.java
@@ -12,12 +12,16 @@ import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
 import java.io.*;
 import java.math.BigInteger;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.security.*;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -98,15 +102,28 @@ public class BasicKeyStore {
   }
 
   public File storeTemp() throws IOException, CertificateException, NoSuchAlgorithmException, KeyStoreException {
-    File temp = File.createTempFile("env-keystore", type().toLowerCase());
-    store(temp.toPath());
-    return temp;
+    // Owner-only permissions are only enforced on POSIX filesystems. On non-POSIX
+    // (e.g. Windows) the file is created with the default inherited ACL.
+    if (FileSystems.getDefault().supportedFileAttributeViews().contains("posix")) {
+      Path temp = Files.createTempFile("env-keystore", type().toLowerCase(),
+          PosixFilePermissions.asFileAttribute(
+              EnumSet.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE)));
+      store(temp);
+      return temp.toFile();
+    } else {
+      Path temp = Files.createTempFile("env-keystore", type().toLowerCase());
+      store(temp);
+      return temp.toFile();
+    }
   }
 
   public void asFile(Consumer<File> c) throws IOException, CertificateException, NoSuchAlgorithmException, KeyStoreException {
     File temp = storeTemp();
-    c.accept(temp);
-    Files.delete(temp.toPath());
+    try {
+      c.accept(temp);
+    } finally {
+      Files.deleteIfExists(temp.toPath());
+    }
   }
 
   protected static java.security.KeyStore createKeyStore(final Reader keyReader, final Reader certReader, final String password)

--- a/src/main/java/com/heroku/sdk/EnvKeyStore.java
+++ b/src/main/java/com/heroku/sdk/EnvKeyStore.java
@@ -222,18 +222,58 @@ public class EnvKeyStore {
     return basicKeyStore.toBytes();
   }
 
+  /**
+   * @deprecated Writing the keystore to disk is out of scope for this library and will be removed
+   * in a subsequent release. Most callers do not need a file at all: use the in-memory
+   * {@link #keyStore()}, or {@link #toBytes()} / {@link #toInputStream()} if bytes are required.
+   * If you truly need a file, implement it in your own code with the permission and cleanup
+   * guarantees appropriate to your environment. Getting this right is filesystem-specific and
+   * security-sensitive: writing a private key to disk with default permissions can expose it to
+   * other local users (CWE-378), so treat this responsibility as yours to own.
+   */
+  @Deprecated
   public void store(OutputStream out) throws CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException {
     basicKeyStore.store(out);
   }
 
+  /**
+   * @deprecated Writing the keystore to disk is out of scope for this library and will be removed
+   * in a subsequent release. Most callers do not need a file at all: use the in-memory
+   * {@link #keyStore()}, or {@link #toBytes()} / {@link #toInputStream()} if bytes are required.
+   * If you truly need a file, implement it in your own code with the permission and cleanup
+   * guarantees appropriate to your environment. Getting this right is filesystem-specific and
+   * security-sensitive: writing a private key to disk with default permissions can expose it to
+   * other local users (CWE-378), so treat this responsibility as yours to own.
+   */
+  @Deprecated
   public void store(Path path) throws CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException {
     basicKeyStore.store(path);
   }
 
+  /**
+   * @deprecated Writing the keystore to disk is out of scope for this library and will be removed
+   * in a subsequent release. Most callers do not need a file at all: use the in-memory
+   * {@link #keyStore()}, or {@link #toBytes()} / {@link #toInputStream()} if bytes are required.
+   * If you truly need a file, implement it in your own code with the permission and cleanup
+   * guarantees appropriate to your environment. Getting this right is filesystem-specific and
+   * security-sensitive: writing a private key to disk with default permissions can expose it to
+   * other local users (CWE-378), so treat this responsibility as yours to own.
+   */
+  @Deprecated
   public File storeTemp() throws IOException, CertificateException, NoSuchAlgorithmException, KeyStoreException {
     return basicKeyStore.storeTemp();
   }
 
+  /**
+   * @deprecated Writing the keystore to disk is out of scope for this library and will be removed
+   * in a subsequent release. Most callers do not need a file at all: use the in-memory
+   * {@link #keyStore()}, or {@link #toBytes()} / {@link #toInputStream()} if bytes are required.
+   * If you truly need a file, implement it in your own code with the permission and cleanup
+   * guarantees appropriate to your environment. Getting this right is filesystem-specific and
+   * security-sensitive: writing a private key to disk with default permissions can expose it to
+   * other local users (CWE-378), so treat this responsibility as yours to own.
+   */
+  @Deprecated
   public void asFile(Consumer<File> c) throws IOException, CertificateException, NoSuchAlgorithmException, KeyStoreException {
     basicKeyStore.asFile(c);
   }

--- a/src/main/java/com/heroku/sdk/EnvKeyStore.java
+++ b/src/main/java/com/heroku/sdk/EnvKeyStore.java
@@ -222,16 +222,6 @@ public class EnvKeyStore {
     return basicKeyStore.toBytes();
   }
 
-  /**
-   * @deprecated Writing the keystore to disk is out of scope for this library and will be removed
-   * in a subsequent release. Most callers do not need a file at all: use the in-memory
-   * {@link #keyStore()}, or {@link #toBytes()} / {@link #toInputStream()} if bytes are required.
-   * If you truly need a file, implement it in your own code with the permission and cleanup
-   * guarantees appropriate to your environment. Getting this right is filesystem-specific and
-   * security-sensitive: writing a private key to disk with default permissions can expose it to
-   * other local users (CWE-378), so treat this responsibility as yours to own.
-   */
-  @Deprecated
   public void store(OutputStream out) throws CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException {
     basicKeyStore.store(out);
   }

--- a/src/main/java/com/heroku/sdk/EnvKeyStore.java
+++ b/src/main/java/com/heroku/sdk/EnvKeyStore.java
@@ -222,6 +222,16 @@ public class EnvKeyStore {
     return basicKeyStore.toBytes();
   }
 
+  /**
+   * @deprecated Writing the keystore to disk is out of scope for this library and will be removed
+   * in a subsequent release. Most callers do not need a file at all: use the in-memory
+   * {@link #keyStore()}, or {@link #toBytes()} / {@link #toInputStream()} if bytes are required.
+   * If you truly need a file, implement it in your own code with the permission and cleanup
+   * guarantees appropriate to your environment. Getting this right is filesystem-specific and
+   * security-sensitive: writing a private key to disk with default permissions can expose it to
+   * other local users (CWE-378), so treat this responsibility as yours to own.
+   */
+  @Deprecated
   public void store(OutputStream out) throws CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException {
     basicKeyStore.store(out);
   }

--- a/src/test/java/com/heroku/sdk/EnvKeyStoreTest.java
+++ b/src/test/java/com/heroku/sdk/EnvKeyStoreTest.java
@@ -8,15 +8,24 @@ import javax.net.ssl.X509TrustManager;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.attribute.PosixFilePermission;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
 
 public class EnvKeyStoreTest {
 
@@ -309,6 +318,49 @@ public class EnvKeyStoreTest {
     assertEquals("KeyStore does not contain 1 entry", 1, eks.keyStore().size());
 
     eks.asFile(f -> assertValidKeyStore(f, eks));
+  }
+
+  @Test
+  public void testStoreTempIsOwnerOnly()
+      throws CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException {
+    assumeTrue(
+        "POSIX file attributes not supported on this filesystem",
+        FileSystems.getDefault().supportedFileAttributeViews().contains("posix"));
+
+    EnvKeyStore eks = new EnvKeyStore(KEY, CERT, PASSWORD);
+    File temp = eks.storeTemp();
+    try {
+      Set<PosixFilePermission> perms = Files.getPosixFilePermissions(temp.toPath());
+      Set<PosixFilePermission> expected =
+          EnumSet.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE);
+      assertEquals("Temp keystore permissions", expected, perms);
+    } finally {
+      Files.deleteIfExists(temp.toPath());
+    }
+  }
+
+  @Test
+  public void testAsFileDeletesOnException()
+      throws CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException {
+    EnvKeyStore eks = new EnvKeyStore(KEY, CERT, PASSWORD);
+    AtomicReference<File> captured = new AtomicReference<>();
+    RuntimeException expected = new RuntimeException("boom");
+
+    RuntimeException caught = null;
+    try {
+      eks.asFile(f -> {
+        captured.set(f);
+        throw expected;
+      });
+    } catch (RuntimeException e) {
+      caught = e;
+    }
+
+    assertSame("Expected asFile to propagate the consumer exception", expected, caught);
+    assertNotNull("Consumer was never invoked", captured.get());
+    assertFalse(
+        "Temp keystore was not deleted after consumer threw: " + captured.get(),
+        captured.get().exists());
   }
 
   private void assertValidKeyStore(File f, EnvKeyStore eks) {


### PR DESCRIPTION
The four disk-IO methods on `EnvKeyStore` (`store(OutputStream)`, `store(Path)`, `storeTemp()`, `asFile(Consumer<File>)`) are auxiliary to the library's intended in-memory usage and undocumented in the README. The two vulnerabilities fixed by this PR both live inside them.

`BasicKeyStore.storeTemp()` wrote its temporary keystore file with `File.createTempFile()`, which respects the process umask and can leave the file readable by other local users (CWE-378). `BasicKeyStore.asFile()` deleted the file after the consumer ran, but the delete was not in a `finally` block, so if the consumer threw an exception the sensitive file was left on disk.

`storeTemp()` now creates the file atomically with owner-only permissions via `Files.createTempFile(..., FileAttribute)`. `asFile()` wraps the consumer in `try` / `finally { Files.deleteIfExists(...) }`. Two tests cover both changes. The permissions test is skipped on non-POSIX via `Assume`.

All four disk-IO methods are marked `@Deprecated` in this PR. Consumers can use the in-memory `KeyStore` returned by `keyStore()` directly, or serialize with `toBytes()` / `toInputStream()` if they need bytes. Those cover essentially every use case for this library. Removal will follow in a subsequent PR, after a release containing the fixes and deprecations from this PR.

The fixes are POSIX-only. This library targets Heroku apps, which run on POSIX. A Windows fix would need `AclFileAttributeView` with a resolved security principal rather than the single atomic call available on POSIX, which is substantially more involved. Given the deprecation above, Windows consumers who need to write the keystore to disk can implement it themselves with the guarantees appropriate to their environment.

GUS-W-23532831